### PR TITLE
Add web UI setup instructions and start ADK server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The Vertex AI RAG Agent allows you to:
 - A Google Cloud project with the Vertex AI API enabled
 - Appropriate access to create and manage Vertex AI resources
 - Python 3.9+ environment
+- Node.js and npm (for web UI)
 
 ## Setting Up Google Cloud Authentication
 
@@ -63,6 +64,72 @@ Before running the agent, you need to set up authentication with Google Cloud:
    ```bash
    pip install -r requirements.txt
    ```
+
+## Setting Up the Web UI
+
+The Google ADK web UI provides a user-friendly interface for interacting with your RAG agent.
+
+### 1. Clone the ADK Web Repository
+
+```bash
+# Clone the Google ADK web UI repository
+git clone https://github.com/google/adk-web
+
+# Install web UI dependencies
+npm install
+```
+
+### 2. Configure Environment Variables
+
+Create a `.env` file in the google-adk-rag directory with your API keys:
+
+```bash
+# In google-adk-RAG/.env
+GOOGLE_API_KEY=your_google_api_key_here
+AGENTOPS_API_KEY=your_agentops_api_key_here
+```
+
+### 3. Update the Server Configuration
+
+**Important**: Update the `agents_dir` variable in `start_adk_server.py` to point to your actual project path:
+
+```python
+# In start_adk_server.py, line 47
+"agents_dir": str("/path/to/google-adk-RAG/"),  # Update this path
+```
+
+Replace `/path/to/` with your actual file system path where the `google-adk-RAG` directory is located.
+
+## Running the Application
+
+You'll need to run both the ADK server and the web UI simultaneously.
+
+### 1. Start the ADK Server
+
+In your first terminal, navigate to the project root and start the server:
+
+```bash
+cd /path/to/google-adk-RAG
+python start_adk_server.py
+```
+
+The server will start on `http://localhost:8000`.
+
+### 2. Start the Web UI
+
+In your second terminal, navigate to the web UI directory and start it:
+
+```bash
+npm run serve --backend=http://localhost:8000
+```
+
+The web UI will be available at `http://localhost:4200`.
+
+### 3. Access the Application
+
+- Open your browser and go to `http://localhost:4200`
+- The web UI will automatically connect to the ADK server running on port 8000
+- You can now interact with your RAG agent through the web interface
 
 ## Using the Agent
 
@@ -117,6 +184,11 @@ If you encounter issues:
 
 - **Missing Dependencies**:
   - Ensure all requirements are installed: `pip install -r requirements.txt`
+
+- **Web UI Connection Issues**:
+  - Verify the ADK server is running on port 8000
+  - Check that the web UI is pointing to the correct backend URL
+  - Ensure both terminals are running the correct commands
 
 ## Additional Resources
 

--- a/rag_agent/agent.py
+++ b/rag_agent/agent.py
@@ -7,6 +7,9 @@ from .tools.delete_document import delete_document
 from .tools.get_corpus_info import get_corpus_info
 from .tools.list_corpora import list_corpora
 from .tools.rag_query import rag_query
+import agentops
+import os
+agentops.init(api_key=os.getenv("AGENTOPS_API_KEY"))
 
 root_agent = Agent(
     name="RagAgent",

--- a/start_adk_server.py
+++ b/start_adk_server.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Start Google ADK API Server for AgentOps Integration
+This script starts the ADK server with proper configuration to work with the AgentOps web UI.
+"""
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+from dotenv import load_dotenv
+
+def start_adk_server():
+    """Start the Google ADK API server with proper configuration"""
+    
+    # Load environment variables
+    load_dotenv()
+  
+    print("🚀 Starting Google ADK API Server for AgentOps Integration")
+    
+    # Check if required environment variables are set
+    required_env_vars = ["GOOGLE_API_KEY", "AGENTOPS_API_KEY"]
+    missing_vars = []
+    
+    for var in required_env_vars:
+        if not os.getenv(var):
+            missing_vars.append(var)
+    
+    if missing_vars:
+        print("❌ Missing required environment variables:")
+        for var in missing_vars:
+            print(f"   - {var}")
+        print("\nPlease set these in your .env file or environment.")
+        return False
+    
+
+    # ADK server configuration
+    server_config = {
+        "host": "0.0.0.0",
+        "port": "8000", 
+        "allow_origins": "http://localhost:4200",
+        "agents_dir": str("path/to/google-adk-RAG/"),  # Point to your adk rag agent
+    }
+    
+    print(f"🔍 Agents Directory: {server_config['agents_dir']}")
+    
+    # Build the ADK server command - agents_dir is passed as positional argument
+    cmd = [
+        "adk", 
+        "api_server",
+        f"--host={server_config['host']}",
+        f"--port={server_config['port']}",
+        f"--allow_origins={server_config['allow_origins']}",
+        server_config['agents_dir'],  # Positional argument for agents directory
+    ]
+    
+    print(f"🔧 Server Configuration:")
+    for key, value in server_config.items():
+        print(f"   {key}: {value}")
+    
+    print(f"\n💻 Command: {' '.join(cmd)}")
+    print("\n" + "="*60)
+    print("🌐 ADK Server will be available at: http://localhost:8000")
+    print("📊 Start the web UI with: npm run serve --backend=http://localhost:8000")
+    print("="*60)
+    
+    try:
+        # Start the server
+        print("\n🎬 Starting server...")
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Error starting ADK server: {e}")
+        return False
+    except KeyboardInterrupt:
+        print("\n🛑 Server stopped by user")
+        return True
+    except FileNotFoundError:
+        print("❌ 'adk' command not found. Please ensure Google ADK is installed:")
+        print("   pip install google-adk")
+        return False
+
+if __name__ == "__main__":
+    success = start_adk_server()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
This PR adds comprehensive instructions for setting up and running the Google ADK web UI alongside the RAG agent server with Agentops.

## AgentOps Dashboard Preview

Below is a preview of how the agent will appear in the AgentOps dashboard:

<img width="1415" height="888" alt="Screenshot 2025-08-07 at 8 08 14 PM" src="https://github.com/user-attachments/assets/5cf60dd7-209e-4dbc-a46c-3bf04f754858" />
